### PR TITLE
updateCell  funciton uses DOM API instead of jQuery API

### DIFF
--- a/slick.grid.js
+++ b/slick.grid.js
@@ -2474,7 +2474,8 @@ if (typeof Slick === "undefined") {
       if (currentEditor && activeRow === row && activeCell === cell) {
         currentEditor.loadValue(d);
       } else {
-    	cellNode.innerHTML = d ? callFormatter(row, cell, getDataItemValueForColumn(d, m), m, d) : "";
+        var formattedValue = d ? callFormatter(row, cell, getDataItemValueForColumn(d, m), m, d) : "";
+    	  cellNode.html(formattedValue); 
         invalidatePostProcessingResults(row);
       }
     }


### PR DESCRIPTION
The _cellNode_ should not be treated as a DOM element as it is a jQuery object.
The current code, is actually the code from the original SlickGrid, trying to set the HTML of the cell using **innerHTML**, while in the X-SlickGrid this element is actually a jQuery object.

The actual way to set the HTML in this element is using the **jQuery.html()** funciton

**NOTE**: There might be a need to review the entire flow and handle this in a lower level (maybe the getCellNode funciton), but this solves the critical issue.
